### PR TITLE
refactor: rename event, function, change recoveryRate type & additional interfaces

### DIFF
--- a/EIPS/eip-5827.md
+++ b/EIPS/eip-5827.md
@@ -31,18 +31,47 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 ```solidity
 pragma solidity ^0.8.0;
 
-interface IERC5827 /* is ERC20 */ {
-    /// @notice Emitted when a new allowance is set.
+interface IERC5827 /* is ERC20, ERC165 */ {
+    /*
+    * Note: the ERC-165 identifier for this interface is 0xT0D0.
+    * 0xTODO ===
+    *   bytes4(keccak256('approveRenewable(address,uint256,uint192)')) ^
+    *   bytes4(keccak256('renewableAllowance(address,address)'))
+    */
+
+    /// @notice Emitted when a new renewable allowance is set.
     /// @param _owner owner of token
     /// @param _spender allowed spender of token
     /// @param _value   initial and maximum allowance given to spender
     /// @param _recoveryRate recovery amount per second
-    event SetRenewableAllowance(
+    event RenewableApproval(
         address indexed _owner,
         address indexed _spender,
         uint256 _value,
         uint192 _recoveryRate
     );
+
+    /// @notice Grants an allowance of `_value` to `_spender` initially, which recovers over time based on `_recoveryRate` up to a limit of `_value`.
+    /// SHOULD throw when `_recoveryRate` is larger than `_value`.
+    /// MUST emit `RenewableApproval` event.
+    /// @param _spender allowed spender of token
+    /// @param _value   initial and maximum allowance given to spender
+    /// @param _recoveryRate recovery amount per second
+    function approveRenewable(
+        address _spender,
+        uint256 _value,
+        uint192 _recoveryRate
+    ) external returns (bool success);
+
+    /// EIP-20 functions
+
+    /// @notice Returns approved max amount and recovery rate.
+    /// @return amount initial and maximum allowance given to spender
+    /// @return recoveryRate recovery amount per second
+    function renewableAllowance(address _owner, address _spender)
+        external
+        view
+        returns (uint256 amount, uint192 recoveryRate);
 
     /// @notice Grants a (non-increasing) allowance of _value to _spender.
     /// MUST clear set _recoveryRate to 0 on the corresponding renewable allowance, if any.
@@ -51,18 +80,6 @@ interface IERC5827 /* is ERC20 */ {
     function approve(address _spender, uint256 _value)
         external
         returns (bool success);
-
-    /// @notice Grants an allowance of `_value` to `_spender` initially, which recovers over time based on `_recoveryRate` up to a limit of `_value`.
-    /// SHOULD throw when `_recoveryRate` is larger than `_value`.
-    /// MUST emit `SetRenewableAllowance` event.
-    /// @param _spender allowed spender of token
-    /// @param _value   initial and maximum allowance given to spender
-    /// @param _recoveryRate recovery amount per second
-    function approve(
-        address _spender,
-        uint256 _value,
-        uint192 _recoveryRate
-    ) external returns (bool success);
 
     /// @notice Moves `amount` tokens from `from` to `to` using the
     /// allowance mechanism. `amount` is then deducted from the caller's
@@ -83,14 +100,6 @@ interface IERC5827 /* is ERC20 */ {
         external
         view
         returns (uint256 remaining);
-
-    /// @notice Returns approved max amount and recovery rate.
-    /// @return amount initial and maximum allowance given to spender
-    /// @return recoveryRate recovery amount per second
-    function renewableAllowance(address _owner, address _spender)
-        external
-        view
-        returns (uint256 amount, uint192 recoveryRate);
 }
 ```
 
@@ -98,27 +107,17 @@ Base method `approve(address _spender, uint256 _value)` MUST set `recoveryRate` 
 
 Both `allowance()` and `transferFrom()` MUST be updated to include allowance recovery logic.
 
-`_value` within `approve(address _spender, uint256 _value, uint192 _recoveryRate)` method sets both initial allowance amount and the maximum allowance limit it can regain to. 
+`_value` within `approveRenewable(address _spender, uint256 _value, uint192 _recoveryRate)` method sets both initial allowance amount and the maximum allowance limit it can regain to. 
 
-### OPTIONAL interfaces
+### Additional interfaces
 
-Differing initial and maximum allowance. 
+Existing EIP-20 tokens can delegate allowance enforcement to a proxy contract that implements this specification. Additional query function exist to get the underlying EIP-20 token.
 
 ```solidity
-interface IERC5827Maximum {
-    /// @notice Grants an allowance of `_value` to `_spender` initially, which recovers over time based on `_recoveryRate` up to a limit of `_value`.
-    /// SHOULD throw when `_recoveryRate` is larger than `_value`.
-    /// MUST emit `SetRenewableAllowance` event.
-    /// @param _spender allowed spender of token
-    /// @param _initialValue initial allowance given to spender
-    /// @param _recoveryRate recovery amount per second
-    /// @param _maxValue maximum allowance that it can regain to
-    function approve(
-        address _spender,
-        uint256 _initialValue,
-        uint192 _recoveryRate,
-        uint256 _maxValue
-    ) external returns (bool success);
+interface IERC5827Proxy {
+    /// @notice Get the underlying base token being proxied.
+    /// @returns baseToken address of the base token
+    function baseToken() external view returns (address);
 }
 ```
 
@@ -129,12 +128,12 @@ interface IERC5827Expirable {
 
     /// @notice Grants an allowance of `_value` to `_spender` initially, which recovers over time based on `_recoveryRate` up to a limit of `_value`. The allowance expires at `_expiration`.
     /// SHOULD throw when `_recoveryRate` is larger than `_value`.
-    /// MUST emit `SetRenewableAllowance` event.
+    /// MUST emit `RenewableApproval` event.
     /// @param _spender allowed spender of token
     /// @param _value initial allowance given to spender
     /// @param _recoveryRate recovery amount per second
     /// @param _expiration time in which the allowance expires
-    function approve(
+    function approveRenewable(
         address _spender,
         uint256 _value,
         uint192 _recoveryRate,

--- a/EIPS/eip-5827.md
+++ b/EIPS/eip-5827.md
@@ -13,7 +13,7 @@ requires: 20, 165
 
 ## Abstract
 
-This optional extension adds a renewable allowance mechanism to [EIP-20](./eip-20.md) allowances, in which a `recoveryRate` defines the amount of token per second that the allowance regains towards the initial maximum approval `amount`.
+This extension adds a renewable allowance mechanism to [EIP-20](./eip-20.md) allowances, in which a `recoveryRate` defines the amount of token per second that the allowance regains towards the initial maximum approval `amount`.
 
 ## Motivation
 
@@ -36,7 +36,10 @@ interface IERC5827 /* is ERC20, ERC165 */ {
     * Note: the ERC-165 identifier for this interface is 0xT0D0.
     * 0xTODO ===
     *   bytes4(keccak256('approveRenewable(address,uint256,uint192)')) ^
-    *   bytes4(keccak256('renewableAllowance(address,address)'))
+    *   bytes4(keccak256('renewableAllowance(address,address)')) ^
+    *   bytes4(keccak256('approve(address,uint256)') ^
+    *   bytes4(keccak256('transferFrom(address,address,uint256)') ^
+    *   bytes4(keccak256('allowance(address,address)') ^
     */
 
     /// @notice Emitted when a new renewable allowance is set.

--- a/EIPS/eip-5827.md
+++ b/EIPS/eip-5827.md
@@ -35,7 +35,7 @@ interface IERC5827 /* is ERC20, ERC165 */ {
     /*
     * Note: the ERC-165 identifier for this interface is 0xT0D0.
     * 0xT0D0 ===
-    *   bytes4(keccak256('approveRenewable(address,uint256,uint192)')) ^
+    *   bytes4(keccak256('approveRenewable(address,uint256,uint256)')) ^
     *   bytes4(keccak256('renewableAllowance(address,address)')) ^
     *   bytes4(keccak256('approve(address,uint256)') ^
     *   bytes4(keccak256('transferFrom(address,address,uint256)') ^
@@ -53,7 +53,7 @@ interface IERC5827 /* is ERC20, ERC165 */ {
         address indexed _owner,
         address indexed _spender,
         uint256 _value,
-        uint192 _recoveryRate
+        uint256 _recoveryRate
     );
 
     /*
@@ -67,7 +67,7 @@ interface IERC5827 /* is ERC20, ERC165 */ {
     function approveRenewable(
         address _spender,
         uint256 _value,
-        uint192 _recoveryRate
+        uint256 _recoveryRate
     ) external returns (bool success);
 
     /// Overridden EIP-20 functions
@@ -80,7 +80,7 @@ interface IERC5827 /* is ERC20, ERC165 */ {
     function renewableAllowance(address _owner, address _spender)
         external
         view
-        returns (uint256 amount, uint192 recoveryRate);
+        returns (uint256 amount, uint256 recoveryRate);
 
     /*
     * @notice Grants a (non-increasing) allowance of _value to _spender.
@@ -122,7 +122,7 @@ Base method `approve(address _spender, uint256 _value)` MUST set `recoveryRate` 
 
 Both `allowance()` and `transferFrom()` MUST be updated to include allowance recovery logic.
 
-`_value` within `approveRenewable(address _spender, uint256 _value, uint192 _recoveryRate)` method sets both initial allowance amount and the maximum allowance limit it can regain to. 
+`_value` within `approveRenewable(address _spender, uint256 _value, uint256 _recoveryRate)` method sets both initial allowance amount and the maximum allowance limit it can regain to. 
 
 ### Additional interfaces
 
@@ -144,6 +144,13 @@ Automatic Expiration
 interface IERC5827Expirable {
 
     /*
+    * Note: the ERC-165 identifier for this interface is 0xT0D0.
+    * 0xT0D0 ===
+    *   bytes4(keccak256('approveRenewable(address,uint256,uint256,uint64)')) ^
+    *   bytes4(keccak256('renewableAllowance(address,address)')) ^
+    */
+
+    /*
     * @notice Grants an allowance of `_value` to `_spender` initially, which recovers over time based on `_recoveryRate` up to a limit of `_value`. The allowance expires at `_expiration`.
     * SHOULD throw when `_recoveryRate` is larger than `_value`.
     * MUST emit `RenewableApproval` event.
@@ -155,7 +162,7 @@ interface IERC5827Expirable {
     function approveRenewable(
         address _spender,
         uint256 _value,
-        uint192 _recoveryRate,
+        uint256 _recoveryRate,
         uint64 _expiration
     ) external returns (bool success);
 
@@ -168,7 +175,7 @@ interface IERC5827Expirable {
     function renewableAllowance(address _owner, address _spender)
         external
         view
-        returns (uint256 amount, uint192 recoveryRate, uint64 expiration);
+        returns (uint256 amount, uint256 recoveryRate, uint64 expiration);
 }
 ```
 

--- a/EIPS/eip-5827.md
+++ b/EIPS/eip-5827.md
@@ -33,14 +33,14 @@ pragma solidity ^0.8.0;
 
 interface IERC5827 /* is ERC20, ERC165 */ {
     /*
-    * Note: the ERC-165 identifier for this interface is 0xT0D0.
-    * 0xT0D0 ===
-    *   bytes4(keccak256('approveRenewable(address,uint256,uint256)')) ^
-    *   bytes4(keccak256('renewableAllowance(address,address)')) ^
-    *   bytes4(keccak256('approve(address,uint256)') ^
-    *   bytes4(keccak256('transferFrom(address,address,uint256)') ^
-    *   bytes4(keccak256('allowance(address,address)') ^
-    */
+     * Note: the ERC-165 identifier for this interface is 0x93cd7af6.
+     * 0x93cd7af6 ===
+     *   bytes4(keccak256('approveRenewable(address,uint256,uint256)')) ^
+     *   bytes4(keccak256('renewableAllowance(address,address)')) ^
+     *   bytes4(keccak256('approve(address,uint256)') ^
+     *   bytes4(keccak256('transferFrom(address,address,uint256)') ^
+     *   bytes4(keccak256('allowance(address,address)') ^
+     */
 
     /*
     * @notice Emitted when a new renewable allowance is set.
@@ -130,6 +130,13 @@ Existing EIP-20 tokens can delegate allowance enforcement to a proxy contract th
 
 ```solidity
 interface IERC5827Proxy {
+
+    /*
+    * Note: the ERC-165 identifier for this interface is 0xc55dae63.
+    * 0xc55dae63 ===
+    *   bytes4(keccak256('baseToken()')
+    */
+
     /*
     * @notice Get the underlying base token being proxied.
     * @returns baseToken address of the base token
@@ -144,8 +151,8 @@ Automatic Expiration
 interface IERC5827Expirable {
 
     /*
-    * Note: the ERC-165 identifier for this interface is 0xT0D0.
-    * 0xT0D0 ===
+    * Note: the ERC-165 identifier for this interface is 0x46c5b619.
+    * 0x46c5b619 ===
     *   bytes4(keccak256('approveRenewable(address,uint256,uint256,uint64)')) ^
     *   bytes4(keccak256('renewableAllowance(address,address)')) ^
     */

--- a/EIPS/eip-5827.md
+++ b/EIPS/eip-5827.md
@@ -34,7 +34,7 @@ pragma solidity ^0.8.0;
 interface IERC5827 /* is ERC20, ERC165 */ {
     /*
     * Note: the ERC-165 identifier for this interface is 0xT0D0.
-    * 0xTODO ===
+    * 0xT0D0 ===
     *   bytes4(keccak256('approveRenewable(address,uint256,uint192)')) ^
     *   bytes4(keccak256('renewableAllowance(address,address)')) ^
     *   bytes4(keccak256('approve(address,uint256)') ^
@@ -42,11 +42,13 @@ interface IERC5827 /* is ERC20, ERC165 */ {
     *   bytes4(keccak256('allowance(address,address)') ^
     */
 
-    /// @notice Emitted when a new renewable allowance is set.
-    /// @param _owner owner of token
-    /// @param _spender allowed spender of token
-    /// @param _value   initial and maximum allowance given to spender
-    /// @param _recoveryRate recovery amount per second
+    /*
+    * @notice Emitted when a new renewable allowance is set.
+    * @param _owner owner of token
+    * @param _spender allowed spender of token
+    * @param _value   initial and maximum allowance given to spender
+    * @param _recoveryRate recovery amount per second
+    */
     event RenewableApproval(
         address indexed _owner,
         address indexed _spender,
@@ -54,51 +56,61 @@ interface IERC5827 /* is ERC20, ERC165 */ {
         uint192 _recoveryRate
     );
 
-    /// @notice Grants an allowance of `_value` to `_spender` initially, which recovers over time based on `_recoveryRate` up to a limit of `_value`.
-    /// SHOULD throw when `_recoveryRate` is larger than `_value`.
-    /// MUST emit `RenewableApproval` event.
-    /// @param _spender allowed spender of token
-    /// @param _value   initial and maximum allowance given to spender
-    /// @param _recoveryRate recovery amount per second
+    /*
+    * @notice Grants an allowance of `_value` to `_spender` initially, which recovers over time based on `_recoveryRate` up to a limit of `_value`.
+    * SHOULD throw when `_recoveryRate` is larger than `_value`.
+    * MUST emit `RenewableApproval` event.
+    * @param _spender allowed spender of token
+    * @param _value   initial and maximum allowance given to spender
+    * @param _recoveryRate recovery amount per second
+    */
     function approveRenewable(
         address _spender,
         uint256 _value,
         uint192 _recoveryRate
     ) external returns (bool success);
 
-    /// EIP-20 functions
+    /// Overridden EIP-20 functions
 
-    /// @notice Returns approved max amount and recovery rate.
-    /// @return amount initial and maximum allowance given to spender
-    /// @return recoveryRate recovery amount per second
+    /*
+    * @notice Returns approved max amount and recovery rate.
+    * @return amount initial and maximum allowance given to spender
+    * @return recoveryRate recovery amount per second
+    */
     function renewableAllowance(address _owner, address _spender)
         external
         view
         returns (uint256 amount, uint192 recoveryRate);
 
-    /// @notice Grants a (non-increasing) allowance of _value to _spender.
-    /// MUST clear set _recoveryRate to 0 on the corresponding renewable allowance, if any.
-    /// @param _spender allowed spender of token
-    /// @param _value   allowance given to spender
+    /*
+    * @notice Grants a (non-increasing) allowance of _value to _spender.
+    * MUST clear set _recoveryRate to 0 on the corresponding renewable allowance, if any.
+    * @param _spender allowed spender of token
+    * @param _value   allowance given to spender
+    */
     function approve(address _spender, uint256 _value)
         external
         returns (bool success);
 
-    /// @notice Moves `amount` tokens from `from` to `to` using the
-    /// allowance mechanism. `amount` is then deducted from the caller's
-    /// allowance factoring in recovery rate logic.
-    /// SHOULD throw when there is insufficient allowance
-    /// @param from token owner address
-    /// @param to token recipient
-    /// @param amount amount of token to transfer
+    /*
+    * @notice Moves `amount` tokens from `from` to `to` using the
+    * allowance mechanism. `amount` is then deducted from the caller's
+    * allowance factoring in recovery rate logic.
+    * SHOULD throw when there is insufficient allowance
+    * @param from token owner address
+    * @param to token recipient
+    * @param amount amount of token to transfer
+    */
     function transferFrom(
         address from,
         address to,
         uint256 amount
     ) external returns (bool);
 
-    /// @notice Returns amounts spendable by `_spender`.
-    /// @return remaining allowance at the current point in time
+    /*
+    * @notice Returns amounts spendable by `_spender`.
+    * @return remaining allowance at the current point in time
+    */
     function allowance(address _owner, address _spender)
         external
         view
@@ -118,8 +130,10 @@ Existing EIP-20 tokens can delegate allowance enforcement to a proxy contract th
 
 ```solidity
 interface IERC5827Proxy {
-    /// @notice Get the underlying base token being proxied.
-    /// @returns baseToken address of the base token
+    /*
+    * @notice Get the underlying base token being proxied.
+    * @returns baseToken address of the base token
+    */
     function baseToken() external view returns (address);
 }
 ```
@@ -129,13 +143,15 @@ Automatic Expiration
 ```solidity
 interface IERC5827Expirable {
 
-    /// @notice Grants an allowance of `_value` to `_spender` initially, which recovers over time based on `_recoveryRate` up to a limit of `_value`. The allowance expires at `_expiration`.
-    /// SHOULD throw when `_recoveryRate` is larger than `_value`.
-    /// MUST emit `RenewableApproval` event.
-    /// @param _spender allowed spender of token
-    /// @param _value initial allowance given to spender
-    /// @param _recoveryRate recovery amount per second
-    /// @param _expiration time in which the allowance expires
+    /*
+    * @notice Grants an allowance of `_value` to `_spender` initially, which recovers over time based on `_recoveryRate` up to a limit of `_value`. The allowance expires at `_expiration`.
+    * SHOULD throw when `_recoveryRate` is larger than `_value`.
+    * MUST emit `RenewableApproval` event.
+    * @param _spender allowed spender of token
+    * @param _value initial allowance given to spender
+    * @param _recoveryRate recovery amount per second
+    * @param _expiration time in which the allowance expires
+    */
     function approveRenewable(
         address _spender,
         uint256 _value,

--- a/EIPS/eip-5827.md
+++ b/EIPS/eip-5827.md
@@ -13,7 +13,7 @@ requires: 20, 165
 
 ## Abstract
 
-This extension adds a renewable allowance mechanism to [EIP-20](./eip-20.md) allowances, in which a `recoveryRate` defines the amount of token per second that the allowance regains towards the initial maximum approval `amount`.
+This optional extension adds a renewable allowance mechanism to [EIP-20](./eip-20.md) allowances, in which a `recoveryRate` defines the amount of token per second that the allowance regains towards the initial maximum approval `amount`.
 
 ## Motivation
 
@@ -31,7 +31,7 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 ```solidity
 pragma solidity ^0.8.0;
 
-interface IERC5827 {
+interface IERC5827 /* is ERC20 */ {
     /// @notice Emitted when a new allowance is set.
     /// @param _owner owner of token
     /// @param _spender allowed spender of token
@@ -43,6 +43,14 @@ interface IERC5827 {
         uint256 _value,
         uint192 _recoveryRate
     );
+
+    /// @notice Grants a (non-increasing) allowance of _value to _spender.
+    /// MUST clear set _recoveryRate to 0 on the corresponding renewable allowance, if any.
+    /// @param _spender allowed spender of token
+    /// @param _value   allowance given to spender
+    function approve(address _spender, uint256 _value)
+        external
+        returns (bool success);
 
     /// @notice Grants an allowance of `_value` to `_spender` initially, which recovers over time based on `_recoveryRate` up to a limit of `_value`.
     /// SHOULD throw when `_recoveryRate` is larger than `_value`.
@@ -86,9 +94,55 @@ interface IERC5827 {
 }
 ```
 
-Base method `approve(address _spender, uint256 _value)` MAY emit `SetRenewableAllowance` with a `recoveryRate` of 0.
+Base method `approve(address _spender, uint256 _value)` MUST set `recoveryRate` to 0.
 
 Both `allowance()` and `transferFrom()` MUST be updated to include allowance recovery logic.
+
+`_value` within `approve(address _spender, uint256 _value, uint192 _recoveryRate)` method sets both initial allowance amount and the maximum allowance limit it can regain to. 
+
+### OPTIONAL interfaces
+
+Differing initial and maximum allowance. 
+
+```solidity
+interface IERC5827Maximum {
+    /// @notice Grants an allowance of `_value` to `_spender` initially, which recovers over time based on `_recoveryRate` up to a limit of `_value`.
+    /// SHOULD throw when `_recoveryRate` is larger than `_value`.
+    /// MUST emit `SetRenewableAllowance` event.
+    /// @param _spender allowed spender of token
+    /// @param _initialValue initial allowance given to spender
+    /// @param _recoveryRate recovery amount per second
+    /// @param _maxValue maximum allowance that it can regain to
+    function approve(
+        address _spender,
+        uint256 _initialValue,
+        uint192 _recoveryRate,
+        uint256 _maxValue
+    ) external returns (bool success);
+}
+```
+
+Automatic Expiration
+
+```solidity
+interface IERC5827Expirable {
+
+    /// @notice Grants an allowance of `_value` to `_spender` initially, which recovers over time based on `_recoveryRate` up to a limit of `_value`. The allowance expires at `_expiration`.
+    /// SHOULD throw when `_recoveryRate` is larger than `_value`.
+    /// MUST emit `SetRenewableAllowance` event.
+    /// @param _spender allowed spender of token
+    /// @param _value initial allowance given to spender
+    /// @param _recoveryRate recovery amount per second
+    /// @param _expiration time in which the allowance expires
+    function approve(
+        address _spender,
+        uint256 _value,
+        uint192 _recoveryRate,
+        uint64 _expiration
+    ) external returns (bool success);
+
+}
+```
 
 ## Rationale
 

--- a/EIPS/eip-5827.md
+++ b/EIPS/eip-5827.md
@@ -159,6 +159,16 @@ interface IERC5827Expirable {
         uint64 _expiration
     ) external returns (bool success);
 
+    /*
+    * @notice Returns approved max amount and recovery rate.
+    * @return amount initial and maximum allowance given to spender
+    * @return recoveryRate recovery amount per second
+    * @return expiration time in which the allowance expires
+    */
+    function renewableAllowance(address _owner, address _spender)
+        external
+        view
+        returns (uint256 amount, uint192 recoveryRate, uint64 expiration);
 }
 ```
 


### PR DESCRIPTION
- Renamed event `SetRenewableAllowance` to `RenewableApproval`
- Rename function `approve` to `approveRenewable`
- Added `IERC5827Proxy` interface
- Added ERC165 interface hashes 
- Switch to uint256 for recoveryRate
- Implementations can still optimise storage by casting to uint192
