### PR TITLE
fix: add Markdown link to first mention of EIP-5827

### DIFF
--- a/EIPS/eip-5827.md
+++ b/EIPS/eip-5827.md
@@ -229,7 +229,7 @@ Existing EIP-20 token contracts can delegate allowance enforcement to a proxy co
 
 This EIP introduces a stricter set of constraints compared to EIP-20 with unlimited allowances. However, when `_recoveryRate` is set to a large value, large amounts can still be transferred over multiple transactions.
 
-Applications that are not EIP-5827-aware may erroneously infer that the value returned by `allowance(address _owner, address _spender)` or included in `Approval` events is the maximum amount of tokens that `_spender` can spend from `_owner`. This may not be the case, such as when a renewable allowance is granted to `_spender` by `_owner`.
+Applications that are not [EIP-5827](./eip-5827.md)-aware may erroneously infer that the value returned by `allowance(address _owner, address _spender)` or included in `Approval` events is the maximum amount of tokens that `_spender` can spend from `_owner`. This may not be the case, such as when a renewable allowance is granted to `_spender` by `_owner`.
 
 ## Copyright
 


### PR DESCRIPTION
(kind of weird, though...)